### PR TITLE
Don't mark internal registers as clobbered

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/switcheroo/src/arch/unix_x64.rs
+++ b/switcheroo/src/arch/unix_x64.rs
@@ -89,7 +89,7 @@ pub unsafe fn swap_and_link_stacks(
         inout("rdx") new_sp => _,
         inout("rdi") arg => ret_val, // 1st argument to called function
         out("rsi") ret_sp, // 2nd argument to called function
-        out("rax") _, out("rbx") _,
+        out("rax") _,
 
         out("r8") _, out("r9") _, out("r10") _, out("r11") _,
         out("r12") _, out("r13") _, out("r14") _, out("r15") _,
@@ -140,7 +140,7 @@ pub unsafe fn swap(arg: usize, new_sp: *mut usize) -> (usize, *mut usize) {
         inout("rdx") new_sp => _,
         inout("rdi") arg => ret_val, // 1st argument to called function
         out("rsi") ret_sp, // 2nd argument to called function
-        out("rax") _, out("rbx") _, out("rcx") _,
+        out("rax") _, out("rcx") _,
 
         out("r8") _, out("r9") _, out("r10") _, out("r11") _,
         out("r12") _, out("r13") _, out("r14") _, out("r15") _,

--- a/tests/async_test.rs
+++ b/tests/async_test.rs
@@ -1,6 +1,5 @@
 use async_executor::LocalExecutor;
 use async_wormhole::AsyncWormhole;
-use backtrace::Backtrace;
 use switcheroo::stack::*;
 
 #[test]
@@ -64,6 +63,8 @@ fn async_yield_drop_with_one_poll() {
 #[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
 #[test]
 fn backtrace_test() {
+    use backtrace::Backtrace;
+
     let stack = EightMbStack::new().unwrap();
     let task = AsyncWormhole::<_, _, fn()>::new(stack, |_yielder| {
         let _ = Backtrace::new_unresolved();


### PR DESCRIPTION
On the most recent rust nightly I get this compile error:

```
  Compiling switcheroo v0.2.8
error: invalid register `rbx`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
  --> /home/kai/.cargo/registry/src/github.com-1ecc6299db9ec823/switcheroo-0.2.8/src/arch/unix_x64.rs:92:23
   |
92 |         out("rax") _, out("rbx") _,
   |                       ^^^^^^^^^^^^

error: invalid register `rbx`: rbx is used internally by LLVM and cannot be used as an operand for inline asm
   --> /home/kai/.cargo/registry/src/github.com-1ecc6299db9ec823/switcheroo-0.2.8/src/arch/unix_x64.rs:143:23
    |
143 |         out("rax") _, out("rbx") _, out("rcx") _,
    |                       ^^^^^^^^^^^^

error: aborting due to 2 previous errors

error: could not compile `switcheroo`
```

So I changed the assembly to not mark those registered as output anymore. Tests work fine, not sure if that potentially breaks other things though. 