### PR TITLE
Use stable asm macro

### DIFF
--- a/switcheroo/src/arch/unix_aarch64.rs
+++ b/switcheroo/src/arch/unix_aarch64.rs
@@ -1,4 +1,5 @@
 use crate::stack;
+use core::arch::asm;
 
 pub unsafe fn init<S: stack::Stack>(
     stack: &S,

--- a/switcheroo/src/arch/unix_x64.rs
+++ b/switcheroo/src/arch/unix_x64.rs
@@ -1,4 +1,5 @@
 use crate::stack;
+use core::arch::asm;
 
 pub unsafe fn init<S: stack::Stack>(
     stack: &S,

--- a/switcheroo/src/arch/windows_x64.rs
+++ b/switcheroo/src/arch/windows_x64.rs
@@ -1,4 +1,5 @@
 use crate::stack;
+use core::arch::asm;
 
 pub unsafe fn init<S: stack::Stack>(
     stack: &S,

--- a/switcheroo/src/lib.rs
+++ b/switcheroo/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(asm, naked_functions)]
+#![feature(naked_functions)]
 
 //! Switcheroo provides lightweight context switches in Rust.
 //!


### PR DESCRIPTION
`asm!` has been stabilized on nightly. All tests pass from what I can tell (have only tested this on unix/x64 though).

It might be god to also add a `rust-toolchain` file to this crate, by the way.